### PR TITLE
Add react-lifecycles-compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6707,6 +6707,11 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
+      "integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ=="
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "precommit": "lint-staged",
     "prepublish": "npm run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "react-lifecycles-compat": "^3.0.2"
+  },
   "peerDependencies": {
-    "react": ">=16.3",
+    "react": ">=0.14.9",
     "prop-types": ">=15.5.7"
   },
   "devDependencies": {

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render } from "react-dom";
 import TestUtils from "react-dom/test-utils";
 
-import OnOff from "..";
+import OnOff from "../OnOff";
 
 let container;
 beforeEach(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { polyfill } from "react-lifecycles-compat";
+
 import OnOff from "./OnOff";
 
-export default OnOff;
+export default polyfill(OnOff);


### PR DESCRIPTION
Adds the `react-lifecycles-compat` polyfill to the build which makes the component compatible with React 0.14.9+.