### PR TITLE
Only set state to off if setOff is called for the on item

### DIFF
--- a/src/OnOffCollection.js
+++ b/src/OnOffCollection.js
@@ -45,7 +45,13 @@ export default class OnOffCollection extends Component {
   };
 
   setOn = id => this.setOnState(id);
-  setOff = () => this.setOnState(null);
+
+  setOff = id => {
+    if (id === this.state.context.on) {
+      this.setOnState(null);
+    }
+  };
+
   toggle = id => {
     const prevOn = this.state.context.on;
     const nextOn = id !== prevOn ? id : null;


### PR DESCRIPTION
There was a bug with the previous implementation where any `setOff` call would set the state of the item that is currently _on_ to _off_.