### PR TITLE
Fix control-prop bugs

### DIFF
--- a/src/OnOffItem.js
+++ b/src/OnOffItem.js
@@ -25,7 +25,7 @@ class OnOffItemImpl extends Component {
     this.props.context.unregisterItem(this.props.id);
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps, _nextState) {
     const id = this.state.id;
     const prevOn = this.props.context.on;
     const nextOn = nextProps.context.on;

--- a/src/OnOffItem.js
+++ b/src/OnOffItem.js
@@ -25,13 +25,13 @@ class OnOffItemImpl extends Component {
     this.props.context.unregisterItem(this.props.id);
   }
 
-  shouldComponentUpdate(nextProps, _nextState) {
+  shouldComponentUpdate(nextProps) {
     const id = this.state.id;
-    const prevOn = this.props.context.on;
-    const nextOn = nextProps.context.on;
-    const itemIsOn = prevOn === id;
+    const prevOnId = this.props.context.on;
+    const nextOnId = nextProps.context.on;
+    const itemIsOn = prevOnId === id;
 
-    return (itemIsOn && nextOn !== id) || (!itemIsOn && nextOn === id);
+    return (itemIsOn && nextOnId !== id) || (!itemIsOn && nextOnId === id);
   }
 
   setOn = () => this.props.context.setOn(this.state.id);

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -46,7 +46,9 @@ test("initial state can be set", () => {
 
 test("state can be controlled", () => {
   const root = render(
-    <OnOff on={true}>{({ on }) => <span>{String(on)}</span>}</OnOff>,
+    <OnOff on={true} defaultOn={false}>
+      {({ on }) => <span>{String(on)}</span>}
+    </OnOff>,
     container
   );
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
@@ -57,18 +59,6 @@ test("state can be controlled", () => {
     container
   );
   expect(span.textContent).toEqual("false");
-});
-
-test("`on` takes precedence over `defaultOn`", () => {
-  const root = render(
-    <OnOff on={true} defaultOn={false}>
-      {({ on }) => <span>{String(on)}</span>}
-    </OnOff>,
-    container
-  );
-  const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
-
-  expect(span.textContent).toEqual("true");
 });
 
 test("`setOn` updates the state to on", () => {
@@ -86,6 +76,7 @@ test("`setOn` updates the state to on", () => {
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
   const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
+  expect(span.textContent).toEqual("false");
   TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("true");
 });
@@ -105,6 +96,7 @@ test("`setOff` updates the state to off", () => {
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
   const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
+  expect(span.textContent).toEqual("true");
   TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("false");
 });
@@ -124,16 +116,16 @@ test("`toggle` toggles the state", () => {
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
   const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
+  expect(span.textContent).toEqual("false");
   TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("true");
   TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("false");
 });
 
-test("state does not change when component is controlled", () => {
-  const onChange = jest.fn();
+test("state doesn't change when component is controlled", () => {
   const root = render(
-    <OnOff on={false} onChange={onChange}>
+    <OnOff on={false}>
       {({ on, setOn }) => (
         <>
           <span>{String(on)}</span>
@@ -149,7 +141,6 @@ test("state does not change when component is controlled", () => {
   expect(span.textContent).toEqual("false");
   TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("false");
-  expect(onChange).toHaveBeenCalledWith(true);
 });
 
 test("`onChange` is called only when state changes", () => {
@@ -169,6 +160,7 @@ test("`onChange` is called only when state changes", () => {
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
   const [setOnButton, setOffButton, toggleButton] = buttons;
 
+  expect(onChange).toHaveBeenCalledTimes(0);
   TestUtils.Simulate.click(toggleButton);
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange).toHaveBeenLastCalledWith(true);

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -118,7 +118,30 @@ test("toggle toggles the state", () => {
   expect(span.textContent).toEqual("false");
 });
 
-test("onChange is triggered only when state changes", () => {
+test("state does not change when component is controlled", () => {
+  const onChange = jest.fn();
+  const root = render(
+    <OnOff on={false} onChange={onChange}>
+      {({ on, setOn }) => (
+        <>
+          <span>{String(on)}</span>
+          <button onClick={setOn}>setOn</button>
+        </>
+      )}
+    </OnOff>,
+    container
+  );
+  const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
+  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
+  const [setOnButton, setOffButton] = buttons;
+
+  expect(span.textContent).toEqual("false");
+  TestUtils.Simulate.click(setOnButton);
+  expect(span.textContent).toEqual("false");
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("onChange is called only when state changes", () => {
   const onChange = jest.fn();
   const root = render(
     <OnOff onChange={onChange}>
@@ -175,5 +198,40 @@ test("should not re-render when the state does not change", () => {
   expect(onRender).toHaveBeenCalledTimes(1);
   TestUtils.Simulate.click(setOnButton);
   TestUtils.Simulate.click(setOnButton);
+  expect(onRender).toHaveBeenCalledTimes(2);
+});
+
+test("should not re-render when the `on` prop does not change", () => {
+  const onRender = jest.fn();
+  render(
+    <OnOff on={false} defaultOn={false} onChange={() => {}}>
+      {({ on }) => {
+        onRender();
+
+        return <span>{String(on)}</span>;
+      }}
+    </OnOff>,
+    container
+  );
+  render(
+    <OnOff on={false} defaultOn={true} onChange={() => {}}>
+      {({ on }) => {
+        onRender();
+
+        return <span>{String(on)}</span>;
+      }}
+    </OnOff>,
+    container
+  );
+  render(
+    <OnOff on={true}>
+      {({ on }) => {
+        onRender();
+
+        return <span>{String(on)}</span>;
+      }}
+    </OnOff>,
+    container
+  );
   expect(onRender).toHaveBeenCalledTimes(2);
 });

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -147,3 +147,33 @@ test("onChange is triggered only when state changes", () => {
   expect(onChange).toHaveBeenCalledTimes(3);
   expect(onChange).toHaveBeenLastCalledWith(true);
 });
+
+test("should not re-render when the state does not change", () => {
+  const onRender = jest.fn();
+  const root = render(
+    <OnOff>
+      {({ setOn, setOff, toggle }) => {
+        onRender();
+
+        return (
+          <>
+            <button onClick={setOn}>setOn</button>
+            <button onClick={setOff}>setOff</button>
+            <button onClick={toggle}>toggle</button>
+          </>
+        );
+      }}
+    </OnOff>,
+    container
+  );
+  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
+  const [setOnButton, setOffButton, toggleButton] = buttons;
+
+  expect(onRender).toHaveBeenCalledTimes(1);
+  TestUtils.Simulate.click(setOffButton);
+  TestUtils.Simulate.click(setOffButton);
+  expect(onRender).toHaveBeenCalledTimes(1);
+  TestUtils.Simulate.click(setOnButton);
+  TestUtils.Simulate.click(setOnButton);
+  expect(onRender).toHaveBeenCalledTimes(2);
+});

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -15,7 +15,7 @@ test("renders without crashing", () => {
   ).not.toThrow();
 });
 
-test("state defaults to off", () => {
+test("initial state is off", () => {
   const root = render(
     <OnOff>
       {({ on, off }) => (
@@ -34,7 +34,7 @@ test("state defaults to off", () => {
   expect(spanOff.textContent).toEqual("true");
 });
 
-test("allows to set initial state", () => {
+test("initial state can be set", () => {
   const root = render(
     <OnOff defaultOn>{({ on }) => <span>{String(on)}</span>}</OnOff>,
     container
@@ -44,7 +44,7 @@ test("allows to set initial state", () => {
   expect(span.textContent).toEqual("true");
 });
 
-test("allows state to be controlled", () => {
+test("state can be controlled", () => {
   const root = render(
     <OnOff on={true}>{({ on }) => <span>{String(on)}</span>}</OnOff>,
     container
@@ -59,13 +59,25 @@ test("allows state to be controlled", () => {
   expect(span.textContent).toEqual("false");
 });
 
-test("setOn updates the state to on", () => {
+test("`on` takes precedence over `defaultOn`", () => {
+  const root = render(
+    <OnOff on={true} defaultOn={false}>
+      {({ on }) => <span>{String(on)}</span>}
+    </OnOff>,
+    container
+  );
+  const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
+
+  expect(span.textContent).toEqual("true");
+});
+
+test("`setOn` updates the state to on", () => {
   const root = render(
     <OnOff>
       {({ on, setOn }) => (
         <>
           <span>{String(on)}</span>
-          <button onClick={setOn}>Update</button>
+          <button onClick={setOn}>setOn</button>
         </>
       )}
     </OnOff>,
@@ -78,13 +90,13 @@ test("setOn updates the state to on", () => {
   expect(span.textContent).toEqual("true");
 });
 
-test("setOff updates the state to off", () => {
+test("`setOff` updates the state to off", () => {
   const root = render(
     <OnOff defaultOn>
       {({ on, setOff }) => (
         <>
           <span>{String(on)}</span>
-          <button onClick={setOff}>Update</button>
+          <button onClick={setOff}>setOff</button>
         </>
       )}
     </OnOff>,
@@ -97,13 +109,13 @@ test("setOff updates the state to off", () => {
   expect(span.textContent).toEqual("false");
 });
 
-test("toggle toggles the state", () => {
+test("`toggle` toggles the state", () => {
   const root = render(
     <OnOff>
       {({ on, toggle }) => (
         <>
           <span>{String(on)}</span>
-          <button onClick={toggle}>Toggle</button>
+          <button onClick={toggle}>toggle</button>
         </>
       )}
     </OnOff>,
@@ -132,16 +144,15 @@ test("state does not change when component is controlled", () => {
     container
   );
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
-  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [setOnButton, setOffButton] = buttons;
+  const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
   expect(span.textContent).toEqual("false");
-  TestUtils.Simulate.click(setOnButton);
+  TestUtils.Simulate.click(button);
   expect(span.textContent).toEqual("false");
-  expect(onChange).not.toHaveBeenCalled();
+  expect(onChange).toHaveBeenCalledWith(true);
 });
 
-test("onChange is called only when state changes", () => {
+test("`onChange` is called only when state changes", () => {
   const onChange = jest.fn();
   const root = render(
     <OnOff onChange={onChange}>
@@ -171,18 +182,17 @@ test("onChange is called only when state changes", () => {
   expect(onChange).toHaveBeenLastCalledWith(true);
 });
 
-test("should not re-render when the state does not change", () => {
+test("doesn't re-render when the state doesn't change", () => {
   const onRender = jest.fn();
   const root = render(
     <OnOff>
-      {({ setOn, setOff, toggle }) => {
+      {({ setOn, setOff }) => {
         onRender();
 
         return (
           <>
             <button onClick={setOn}>setOn</button>
             <button onClick={setOff}>setOff</button>
-            <button onClick={toggle}>toggle</button>
           </>
         );
       }}
@@ -190,7 +200,7 @@ test("should not re-render when the state does not change", () => {
     container
   );
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [setOnButton, setOffButton, toggleButton] = buttons;
+  const [setOnButton, setOffButton] = buttons;
 
   expect(onRender).toHaveBeenCalledTimes(1);
   TestUtils.Simulate.click(setOffButton);
@@ -201,7 +211,7 @@ test("should not re-render when the state does not change", () => {
   expect(onRender).toHaveBeenCalledTimes(2);
 });
 
-test("should not re-render when the `on` prop does not change", () => {
+test("doesn't re-render when the `on` prop doesn't change", () => {
   const onRender = jest.fn();
   render(
     <OnOff on={false} defaultOn={false} onChange={() => {}}>

--- a/src/__tests__/OnOff.js
+++ b/src/__tests__/OnOff.js
@@ -74,10 +74,10 @@ test("`setOn` updates the state to on", () => {
     container
   );
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
-  const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
+  const setOnButton = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
   expect(span.textContent).toEqual("false");
-  TestUtils.Simulate.click(button);
+  TestUtils.Simulate.click(setOnButton);
   expect(span.textContent).toEqual("true");
 });
 
@@ -114,12 +114,15 @@ test("`toggle` toggles the state", () => {
     container
   );
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
-  const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
+  const toggleButton = TestUtils.findRenderedDOMComponentWithTag(
+    root,
+    "button"
+  );
 
   expect(span.textContent).toEqual("false");
-  TestUtils.Simulate.click(button);
+  TestUtils.Simulate.click(toggleButton);
   expect(span.textContent).toEqual("true");
-  TestUtils.Simulate.click(button);
+  TestUtils.Simulate.click(toggleButton);
   expect(span.textContent).toEqual("false");
 });
 
@@ -136,10 +139,10 @@ test("state doesn't change when component is controlled", () => {
     container
   );
   const span = TestUtils.findRenderedDOMComponentWithTag(root, "span");
-  const button = TestUtils.findRenderedDOMComponentWithTag(root, "button");
+  const setOnButton = TestUtils.findRenderedDOMComponentWithTag(root, "button");
 
   expect(span.textContent).toEqual("false");
-  TestUtils.Simulate.click(button);
+  TestUtils.Simulate.click(setOnButton);
   expect(span.textContent).toEqual("false");
 });
 
@@ -235,5 +238,6 @@ test("doesn't re-render when the `on` prop doesn't change", () => {
     </OnOff>,
     container
   );
+
   expect(onRender).toHaveBeenCalledTimes(2);
 });

--- a/src/__tests__/OnOffCollection.js
+++ b/src/__tests__/OnOffCollection.js
@@ -215,6 +215,40 @@ test("`toggle` toggles the item states", () => {
   expect(spanItem2.textContent).toEqual("false");
 });
 
+test("state doesn't change when component is controlled", () => {
+  const root = render(
+    <OnOffCollection on="1">
+      <OnOffItem id="1">
+        {({ on, toggle }) => (
+          <>
+            <span>{String(on)}</span>
+            <button onClick={toggle}>toggle</button>
+          </>
+        )}
+      </OnOffItem>
+      <OnOffItem id="2">
+        {({ on, toggle }) => (
+          <>
+            <span>{String(on)}</span>
+            <button onClick={toggle}>toggle</button>
+          </>
+        )}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+  const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
+  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
+  const [spanItem1, spanItem2] = spans;
+  const [toggleButtonItem1, toggleButtonItem2] = buttons;
+
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(toggleButtonItem2);
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+});
+
 test("`onChange` is called only when state changes", () => {
   const onChange = jest.fn();
   const root = render(

--- a/src/__tests__/OnOffCollection.js
+++ b/src/__tests__/OnOffCollection.js
@@ -49,7 +49,7 @@ test("item id's default to unique id's", () => {
   expect(span1.textContent).not.toEqual(span2.textContent);
 });
 
-test("allows to set initial state", () => {
+test("initial state can be set", () => {
   const root = render(
     <OnOffCollection defaultOn="1">
       <OnOffItem id="1">{({ on }) => <span>{String(on)}</span>}</OnOffItem>
@@ -64,7 +64,7 @@ test("allows to set initial state", () => {
   expect(span2.textContent).toEqual("false");
 });
 
-test("allows state to be controlled", () => {
+test("state can be controlled", () => {
   const root = render(
     <OnOffCollection defaultOn="1" on="2">
       <OnOffItem id="1">{({ on }) => <span>{String(on)}</span>}</OnOffItem>
@@ -97,42 +97,7 @@ test("allows state to be controlled", () => {
   expect(span2.textContent).toEqual("false");
 });
 
-test("setOn sets item states to on", () => {
-  const root = render(
-    <OnOffCollection>
-      <OnOffItem id="1">
-        {({ on, setOn }) => (
-          <>
-            <span>{String(on)}</span>
-            <button onClick={setOn}>Update</button>
-          </>
-        )}
-      </OnOffItem>
-      <OnOffItem>
-        {({ on, setOn }) => (
-          <>
-            <span>{String(on)}</span>
-            <button onClick={setOn}>setOn</button>
-          </>
-        )}
-      </OnOffItem>
-    </OnOffCollection>,
-    container
-  );
-  const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
-  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [span1, span2] = spans;
-  const [button1, button2] = buttons;
-
-  TestUtils.Simulate.click(button1);
-  expect(span1.textContent).toEqual("true");
-  expect(span2.textContent).toEqual("false");
-  TestUtils.Simulate.click(button2);
-  expect(span1.textContent).toEqual("false");
-  expect(span2.textContent).toEqual("true");
-});
-
-test("setOff sets item states to off", () => {
+test("`setOff` sets item states to off", () => {
   const root = render(
     <OnOffCollection defaultOn="1">
       <OnOffItem id="1">
@@ -157,18 +122,60 @@ test("setOff sets item states to off", () => {
   );
   const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [span1, span2] = spans;
-  const [setOffButton1, setOnButton, setOffButton2] = buttons;
+  const [spanItem1, spanItem2] = spans;
+  const [setOffButtonItem1, setOnButtonItem2, setOffButtonItem2] = buttons;
 
-  TestUtils.Simulate.click(setOffButton1);
-  expect(span1.textContent).toEqual("false");
-  TestUtils.Simulate.click(setOnButton);
-  expect(span2.textContent).toEqual("true");
-  TestUtils.Simulate.click(setOffButton2);
-  expect(span2.textContent).toEqual("false");
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(setOffButtonItem1);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(setOnButtonItem2);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("true");
+  TestUtils.Simulate.click(setOffButtonItem2);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("false");
 });
 
-test("toggle toggles the item states", () => {
+test("`setOn` sets item states to on", () => {
+  const root = render(
+    <OnOffCollection>
+      <OnOffItem id="1">
+        {({ on, setOn }) => (
+          <>
+            <span>{String(on)}</span>
+            <button onClick={setOn}>Update</button>
+          </>
+        )}
+      </OnOffItem>
+      <OnOffItem>
+        {({ on, setOn }) => (
+          <>
+            <span>{String(on)}</span>
+            <button onClick={setOn}>setOn</button>
+          </>
+        )}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+  const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
+  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
+  const [spanItem1, spanItem2] = spans;
+  const [setOnButtonItem1, setOnButtonItem2] = buttons;
+
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(setOnButtonItem1);
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(setOnButtonItem2);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("true");
+});
+
+test("`toggle` toggles the item states", () => {
   const root = render(
     <OnOffCollection defaultOn="1">
       <OnOffItem id="1">
@@ -192,21 +199,23 @@ test("toggle toggles the item states", () => {
   );
   const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [span1, span2] = spans;
-  const [button1, button2] = buttons;
+  const [spanItem1, spanItem2] = spans;
+  const [toggleButtonItem1, toggleButtonItem2] = buttons;
 
-  TestUtils.Simulate.click(button2);
-  expect(span1.textContent).toEqual("false");
-  expect(span2.textContent).toEqual("true");
-  TestUtils.Simulate.click(button2);
-  expect(span1.textContent).toEqual("false");
-  expect(span2.textContent).toEqual("false");
-  TestUtils.Simulate.click(button1);
-  expect(span1.textContent).toEqual("true");
-  expect(span2.textContent).toEqual("false");
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(toggleButtonItem2);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("true");
+  TestUtils.Simulate.click(toggleButtonItem2);
+  expect(spanItem1.textContent).toEqual("false");
+  expect(spanItem2.textContent).toEqual("false");
+  TestUtils.Simulate.click(toggleButtonItem1);
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
 });
 
-test("onChange is called only when state changes", () => {
+test("`onChange` is called only when state changes", () => {
   const onChange = jest.fn();
   const root = render(
     <OnOffCollection defaultOn="1" onChange={onChange}>
@@ -226,36 +235,36 @@ test("onChange is called only when state changes", () => {
   );
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
   const [
-    setOnButton1,
-    setOffButton1,
-    toggleButton1,
-    setOnButton2,
-    setOffButton2,
-    toggleButton2
+    setOnButtonItem1,
+    setOffButtonItem1,
+    toggleButtonItem1,
+    setOnButtonItem2,
+    setOffButtonItem2,
+    toggleButtonItem2
   ] = buttons;
 
-  TestUtils.Simulate.click(setOnButton1);
   expect(onChange).toHaveBeenCalledTimes(0);
-  TestUtils.Simulate.click(setOnButton2);
+  TestUtils.Simulate.click(setOnButtonItem1);
+  expect(onChange).toHaveBeenCalledTimes(0);
+  TestUtils.Simulate.click(setOnButtonItem2);
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange).toHaveBeenLastCalledWith("2");
-  TestUtils.Simulate.click(setOffButton2);
+  TestUtils.Simulate.click(setOffButtonItem2);
   expect(onChange).toHaveBeenCalledTimes(2);
   expect(onChange).toHaveBeenLastCalledWith(null);
-  TestUtils.Simulate.click(setOffButton2);
+  TestUtils.Simulate.click(setOffButtonItem2);
   expect(onChange).toHaveBeenCalledTimes(2);
-  TestUtils.Simulate.click(toggleButton1);
+  TestUtils.Simulate.click(toggleButtonItem1);
   expect(onChange).toHaveBeenCalledTimes(3);
   expect(onChange).toHaveBeenLastCalledWith("1");
-  TestUtils.Simulate.click(toggleButton2);
+  TestUtils.Simulate.click(toggleButtonItem2);
   expect(onChange).toHaveBeenCalledTimes(4);
   expect(onChange).toHaveBeenLastCalledWith("2");
 });
 
 test("resets the state when items unmount", () => {
-  const onChange = jest.fn();
   const root = render(
-    <OnOffCollection defaultOn="1" onChange={onChange}>
+    <OnOffCollection defaultOn="1">
       {["1", "2"].map(stateId => (
         <OnOff key={stateId} defaultOn>
           {({ on: isItemVisible, toggle: toggleItem }) => (
@@ -276,17 +285,17 @@ test("resets the state when items unmount", () => {
 
   const spans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
   const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
-  const [span1, span2] = spans;
-  const [toggleItemButton1, toggleItemButton2] = buttons;
+  const [spanItem1, spanItem2] = spans;
+  const [toggleButtonItem1, toggleButtonItem2] = buttons;
 
-  expect(span1.textContent).toEqual("true");
-  expect(span2.textContent).toEqual("false");
-  TestUtils.Simulate.click(toggleItemButton1);
-  expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenLastCalledWith(null);
-  TestUtils.Simulate.click(toggleItemButton1);
-  const newSpans = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
-  const [newSpan1, newSpan2] = newSpans;
-  expect(newSpan1.textContent).toEqual("false");
-  expect(newSpan2.textContent).toEqual("false");
+  expect(spanItem1.textContent).toEqual("true");
+  expect(spanItem2.textContent).toEqual("false");
+  // Unmount first item
+  TestUtils.Simulate.click(toggleButtonItem1);
+  // Mount first item
+  TestUtils.Simulate.click(toggleButtonItem1);
+  const spansUpdated = TestUtils.scryRenderedDOMComponentsWithTag(root, "span");
+  const [spanItem1Updated, spanItem2Updated] = spansUpdated;
+  expect(spanItem1Updated.textContent).toEqual("false");
+  expect(spanItem2Updated.textContent).toEqual("false");
 });

--- a/src/__tests__/OnOffCollection.js
+++ b/src/__tests__/OnOffCollection.js
@@ -333,3 +333,78 @@ test("resets the state when items unmount", () => {
   expect(spanItem1Updated.textContent).toEqual("false");
   expect(spanItem2Updated.textContent).toEqual("false");
 });
+
+test("doesn't re-render when the state doesn't change", () => {
+  const onRender = jest.fn();
+  const root = render(
+    <OnOffCollection>
+      <OnOffItem>
+        {({ on, setOn, setOff, toggle }) => {
+          onRender();
+
+          return (
+            <>
+              <span>{String(on)}</span>
+              <button onClick={setOn}>setOn</button>
+              <button onClick={setOff}>setOff</button>
+              <button onClick={toggle}>toggle</button>
+            </>
+          );
+        }}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+  const buttons = TestUtils.scryRenderedDOMComponentsWithTag(root, "button");
+  const [setOnButton, setOffButton, toggleButton] = buttons;
+
+  expect(onRender).toHaveBeenCalledTimes(1);
+  TestUtils.Simulate.click(setOffButton);
+  TestUtils.Simulate.click(setOffButton);
+  expect(onRender).toHaveBeenCalledTimes(1);
+  TestUtils.Simulate.click(setOnButton);
+  TestUtils.Simulate.click(setOnButton);
+  expect(onRender).toHaveBeenCalledTimes(2);
+});
+
+test("doesn't re-render when the `on` prop doesn't change", () => {
+  const onRender = jest.fn();
+  render(
+    <OnOffCollection on="1" defaultOn="1" onChange={() => {}}>
+      <OnOffItem id="1">
+        {({ on }) => {
+          onRender();
+
+          return <span>{String(on)}</span>;
+        }}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+  render(
+    <OnOffCollection on="1" defaultOn={null} onChange={() => {}}>
+      <OnOffItem id="1">
+        {({ on }) => {
+          onRender();
+
+          return <span>{String(on)}</span>;
+        }}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+  render(
+    <OnOffCollection on={null}>
+      <OnOffItem id="1">
+        {({ on }) => {
+          onRender();
+
+          return <span>{String(on)}</span>;
+        }}
+      </OnOffItem>
+    </OnOffCollection>,
+    container
+  );
+
+  expect(onRender).toHaveBeenCalledTimes(2);
+});

--- a/src/__tests__/OnOffItem.js
+++ b/src/__tests__/OnOffItem.js
@@ -41,7 +41,7 @@ test("state defaults to off", () => {
   expect(spanOff.textContent).toEqual("true");
 });
 
-test("allows to set id", () => {
+test("passes on id prop", () => {
   const root = render(
     <TestWrapper>
       <OnOffItem id="foo">{({ id }) => <span>{String(id)}</span>}</OnOffItem>


### PR DESCRIPTION
There's a bug in the current implementation when using the control prop. The `on` prop doesn't take precedence over internal state changes. Also, copying prop changes with `getDerivedStateFromProps` is not necessary.